### PR TITLE
"headerStyle" tag attribute on column

### DIFF
--- a/displaytag/src/main/java/org/displaytag/tags/ColumnTag.java
+++ b/displaytag/src/main/java/org/displaytag/tags/ColumnTag.java
@@ -490,6 +490,15 @@ public class ColumnTag extends BodyTagSupport implements MediaUtil.SupportsMedia
     }
 
     /**
+     * setter for the "headerStyle" tag attribute.
+     * @param value attribute value
+     */
+    public void setHeaderStyle(String value)
+    {
+        this.headerAttributeMap.put(TagConstants.ATTRIBUTE_STYLE, value);
+    }
+
+    /**
      * setter for the "class" tag attribute.
      * @param value attribute value
      */

--- a/displaytag/src/main/java/org/displaytag/tags/ColumnTagBeanInfo.java
+++ b/displaytag/src/main/java/org/displaytag/tags/ColumnTagBeanInfo.java
@@ -70,6 +70,10 @@ public class ColumnTagBeanInfo extends SimpleBeanInfo
                 ColumnTag.class,
                 null,
                 "setHeaderClass")); //$NON-NLS-1$
+            proplist.add(new PropertyDescriptor("headerStyle", //$NON-NLS-1$
+                ColumnTag.class,
+                null,
+                "setHeaderStyle")); //$NON-NLS-1$
             proplist.add(new PropertyDescriptor("href", //$NON-NLS-1$
                 ColumnTag.class,
                 null,

--- a/displaytag/src/main/resources/META-INF/displaytag.tld
+++ b/displaytag/src/main/resources/META-INF/displaytag.tld
@@ -534,6 +534,13 @@
       <description>html pass through attribute.</description>
     </attribute>
     <attribute>
+      <name>headerStyle</name>
+      <required>false</required>
+      <rtexprvalue>true</rtexprvalue>
+      <type>java.lang.String</type>
+      <description>html pass through attribute added only for header cells.</description>
+    </attribute>
+    <attribute>
       <name>group</name>
       <required>false</required>
       <rtexprvalue>true</rtexprvalue>

--- a/displaytag/src/test/java/org/displaytag/jsptests/HtmlAttributesTest.java
+++ b/displaytag/src/test/java/org/displaytag/jsptests/HtmlAttributesTest.java
@@ -80,9 +80,12 @@ public class HtmlAttributesTest extends DisplaytagCase
         Assert.assertEquals("invalid attribute value", "summaryX", table.getAttribute("summary"));
         Assert.assertEquals("invalid attribute value", "classX table", table.getAttribute("class"));
 
+        TableCell header = table.getTableCell(0, 0);
+        Assert.assertEquals("invalid attribute value", "classH", header.getAttribute("class"));
+        Assert.assertEquals("invalid attribute value", "styleH", header.getAttribute("style"));
+
         TableCell cell = table.getTableCell(1, 0);
         Assert.assertEquals("invalid attribute value", "styleX", cell.getAttribute("style"));
         Assert.assertEquals("invalid attribute value", "classX", cell.getAttribute("class"));
-
     }
 }

--- a/displaytag/src/test/resources/jsps/htmlattributes.jsp
+++ b/displaytag/src/test/resources/jsps/htmlattributes.jsp
@@ -20,7 +20,7 @@
 
   <display:table name="test" htmlId="idX" cellspacing="cellspacingX" cellpadding="cellpaddingX"
     frame="frameX" rules="rulesX" style="styleX" summary="summaryX" class="classX">
-    <display:column property="ant" style="styleX" class="classX"/>
+    <display:column property="ant" style="styleX" class="classX" headerStyle="styleH" headerClass="classH"/>
   </display:table>
   </body>
   </html>


### PR DESCRIPTION
"headerStyle" - html pass through attribute added only for header cells (display:column tag)