### PR TITLE
fix: setupViewableData uses decorator but decorator was set after its…

### DIFF
--- a/displaytag/src/main/java/org/displaytag/tags/TableTag.java
+++ b/displaytag/src/main/java/org/displaytag/tags/TableTag.java
@@ -1286,13 +1286,13 @@ public class TableTag extends HtmlTableTag
             this.pageContext,
             getConfiguredDecoratorName());
 
-        setupViewableData();
-
         if (tableDecorator != null)
         {
             tableDecorator.init(this.pageContext, this.list, this.tableModel);
             this.tableModel.setTableDecorator(tableDecorator);
         }
+
+        setupViewableData();
 
         TableTotaler totaler = this.properties.getDecoratorFactoryInstance().loadTableTotaler(
             this.pageContext,


### PR DESCRIPTION
If table has a row added by a decorator then it cannot be displayed because setTableDecorator was called after setupViewableData and it throws an exception.

org.displaytag.exception.RuntimeLookupException: LookupException while trying to fetch property "sortCreatedAt". Cause: Error looking up property "sortCreatedAt" in object type ...
at org.displaytag.model.RowSorter.compare(RowSorter.java:162)
	at java.base/java.util.TimSort.countRunAndMakeAscending(TimSort.java:355)
	at java.base/java.util.TimSort.sort(TimSort.java:220)
	at java.base/java.util.Arrays.sort(Arrays.java:1515)
	at java.base/java.util.ArrayList.sort(ArrayList.java:1749)
	at java.base/java.util.Collections.sort(Collections.java:177)
	at org.displaytag.model.TableModel.sortRowList(TableModel.java:503)
	at org.displaytag.model.TableModel.sortFullList(TableModel.java:538)
	at org.displaytag.tags.TableTag.setupViewableData(TableTag.java:1638)