### PR TITLE
Use api's for jakarta annotaton and el rather than tomcat inbedded copies

### DIFF
--- a/displaytag/pom.xml
+++ b/displaytag/pom.xml
@@ -362,6 +362,12 @@
       <version>6.0.53</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>jakarta.el</groupId>
+      <artifactId>jakarta.el-api</artifactId>
+      <version>3.0.3</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/displaytag/pom.xml
+++ b/displaytag/pom.xml
@@ -388,6 +388,12 @@
       <version>3.0.3</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.glassfish</groupId>
+      <artifactId>jakarta.el</artifactId>
+      <version>3.0.3</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/displaytag/pom.xml
+++ b/displaytag/pom.xml
@@ -361,6 +361,11 @@
       <artifactId>jasper-el</artifactId>
       <version>6.0.53</version>
       <scope>test</scope>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+      <version>1.3.5</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>jakarta.el</groupId>

--- a/displaytag/pom.xml
+++ b/displaytag/pom.xml
@@ -354,6 +354,14 @@
           <artifactId>servlet-api</artifactId>
           <groupId>org.apache.tomcat</groupId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.tomcat</groupId>
+          <artifactId>el-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.tomcat</groupId>
+          <artifactId>annotations-api</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -361,6 +369,13 @@
       <artifactId>jasper-el</artifactId>
       <version>6.0.53</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.tomcat</groupId>
+          <artifactId>el-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
     <dependency>
       <groupId>jakarta.annotation</groupId>
       <artifactId>jakarta.annotation-api</artifactId>


### PR DESCRIPTION
part of effort to get to modern tomcat.