### PR TITLE
Make the default value of column 'escapeXml' attribute configurable

### DIFF
--- a/displaytag/src/main/java/org/displaytag/properties/TableProperties.java
+++ b/displaytag/src/main/java/org/displaytag/properties/TableProperties.java
@@ -373,6 +373,11 @@ public final class TableProperties implements Cloneable {
      * Will be overriden by column level comparators.
      */
     public static final String PROPERTY_DEFAULT_COMPARATOR = "comparator.default"; //$NON-NLS-1$
+    
+    /**
+     * Property <code>escapeXml.default</code>. Specifies the default value for column <code>escapeXml</code> attribute.
+     */
+    public static final String PROPERTY_BOOLEAN_ESCAPEXML_DEFAULT = "escapeXml.default"; //$NON-NLS-1$
 
     // </JBN>
 
@@ -1386,5 +1391,14 @@ public final class TableProperties implements Cloneable {
             }
         }
         return new DefaultComparator(Collator.getInstance(this.getLocale()));
+    }
+ 
+    /**
+     * Returns the default value for column <code>escapeXml</code> attribute.
+     * 
+     * @return The default value for column <code>escapeXml</code> attribute
+     */
+    public boolean getEscapeXmlDefault() {
+    	return getBooleanProperty(PROPERTY_BOOLEAN_ESCAPEXML_DEFAULT);
     }
 }

--- a/displaytag/src/main/java/org/displaytag/tags/ColumnTag.java
+++ b/displaytag/src/main/java/org/displaytag/tags/ColumnTag.java
@@ -139,7 +139,7 @@ public class ColumnTag extends BodyTagSupport implements MediaUtil.SupportsMedia
     /**
      * Automatically escape column content for html and xml media.
      */
-    private boolean escapeXml;
+    private Boolean escapeXml;
 
     /**
      * A MessageFormat patter that will be used to decorate objects in the column. Can be used as a "shortcut" for
@@ -721,7 +721,7 @@ public class ColumnTag extends BodyTagSupport implements MediaUtil.SupportsMedia
         }
 
         // "special" decorators
-        if (this.escapeXml) {
+        if (this.escapeXml != null && this.escapeXml) {
             decorators.add(EscapeXmlColumnDecorator.INSTANCE);
         }
         if (this.autolink) {
@@ -835,7 +835,7 @@ public class ColumnTag extends BodyTagSupport implements MediaUtil.SupportsMedia
         this.sortProperty = null;
         this.comparator = null;
         this.defaultorder = null;
-        this.escapeXml = false;
+        this.escapeXml = null;
         this.format = null;
         this.value = null;
         this.totaled = false;
@@ -867,6 +867,11 @@ public class ColumnTag extends BodyTagSupport implements MediaUtil.SupportsMedia
                 .findAttribute(TableTag.PAGE_ATTRIBUTE_MEDIA);
         if (!MediaUtil.availableForMedia(this, currentMediaType)) {
             return Tag.SKIP_BODY;
+        }
+        
+        // Configure escapeXml default value from properties
+        if (this.escapeXml == null) {
+        	this.escapeXml = tableTag.getProperties().getEscapeXmlDefault();
         }
 
         return super.doStartTag();


### PR DESCRIPTION
Make the default value of column `escapeXml` attribute configurable via `displaytag.properties`. The default value can be set to true using the following configuration. If not configured, the default remains false for backwards compatibility.

```
escapeXml.default=true
```

Being able to escape column content by default makes it easier to avoid cross-site scripting vulnerabilities by selectively turning of escaping only where raw HTML output is actually required and safe.