### PR TITLE
Use requestSubmit() instead of submit()

### DIFF
--- a/displaytag/src/main/java/org/displaytag/render/HtmlTableWriter.java
+++ b/displaytag/src/main/java/org/displaytag/render/HtmlTableWriter.java
@@ -172,7 +172,7 @@ public class HtmlTableWriter extends TableWriterAdapter {
             final String js = "<script type=\"text/javascript\">\n" + "function displaytagform(formname, fields){\n"
                     + "    var objfrm = document.forms[formname];\n"
                     + "    for (j=fields.length-1;j>=0;j--){var f= objfrm.elements[fields[j].f];if (f){f.value=fields[j].v};}\n"
-                    + "    objfrm.submit();\n" + "}\n" + "</script>";
+                    + "    objfrm.requestSubmit();\n" + "}\n" + "</script>";
             this.writeFormFields(model);
             this.write(js);
         }


### PR DESCRIPTION
The `submit()` method does _not_ fire a `submit` browser event; `requestSubmit()` does. 

This gives the end user some additional flexibility in extending or customizing the behavior of form submission. 

For example, a simple pre-submit logger: 

```javascript
document.getElementById("form-name")
    .addEventListener("submit", (event) => {
        event.preventDefault();
        const form = event.target;
        const formData = new FormData(form);
        console.debug({ formData });
        form.submit();
    });
```

You can see the possibilities; adding tokens, required params, validation, etc.